### PR TITLE
Remove main branch condition for publish

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -40,7 +40,7 @@ jobs:
   publish:
     needs: build_and_test
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'release' && github.ref == 'refs/heads/main' }}
+    if: ${{ github.event_name == 'release' }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3


### PR DESCRIPTION
This was causing the job to be skipped because the ref is actually a tag in this case.